### PR TITLE
Added a formula for version 3.9.0 of Watchman

### DIFF
--- a/watchman390.rb
+++ b/watchman390.rb
@@ -1,0 +1,40 @@
+class Watchman390 < Formula
+  desc "Watch files and take action when they change"
+  homepage "https://github.com/facebook/watchman"
+  url "https://github.com/facebook/watchman/archive/v3.9.0.tar.gz"
+  sha256 "1739cd2d6846cc688b12911c37406fae5601d76c0d11f3da957c2b7273941221"
+
+  conflicts_with "watchman", :because => "Differing versions of the same formula"
+
+  depends_on :python if MacOS.version <= :snow_leopard
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "pcre"
+
+  def install
+    system "./autogen.sh"
+    system "./configure", "--disable-dependency-tracking",
+                          "--prefix=#{prefix}",
+                          "--with-pcre",
+                          # we'll do the homebrew specific python
+                          # installation below
+                          "--without-python"
+    system "make"
+    system "make", "install"
+
+    # Homebrew specific python application installation
+    ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python2.7/site-packages"
+    cd "python" do
+      system "python", *Language::Python.setup_install_args(libexec)
+    end
+    bin.install Dir[libexec/"bin/*"]
+    bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
+  end
+
+  test do
+    list = shell_output("#{bin}/watchman -v")
+    if list.index(version).nil?
+      raise "expected to see #{version} in the version output"
+    end
+  end
+end


### PR DESCRIPTION
Ember CLI pitches a hissy fit and falls back to node watcher if you use the current version that brew installs
